### PR TITLE
Update docs for current metadata layout

### DIFF
--- a/AI_README.md
+++ b/AI_README.md
@@ -1,14 +1,13 @@
 <!-- AI_README.md: Comprehensive guide for the AI assistant on the Image Processor project -->
 # AI Assistant Guide: Image Processor Project
 
-This document equips the AI assistant with everything needed to navigate, understand, and modify the Image Processor codebase. It includes architecture overviews, directory structure, development workflows, storage conventions (current and planned), and AI-specific coding guidelines.
+This document equips the AI assistant with everything needed to navigate, understand, and modify the Image Processor codebase. It includes architecture overviews, directory structure, development workflows, storage conventions, and AI-specific coding guidelines.
 
 ---
 
 ## 1. Base Prompt & Goals
 - **Base Prompt**: See `BASE_PROMPT.md` for the foundational system instructions.
 - **Primary Objective**: Enable the AI to propose, draft, and apply precise, minimal changes that adhere to project conventions, pass all tests, and commit the changes into git.
-- **Current Task**: Revise the backend storage to use a single `metadata/` directory with layered subdirectories. Each leaf directory will contain all per-file data (dialog, timestamps, AI annotations, etc.) and a symlink back to the original image. Symlinks must update when files are moved or renamed.
   
 ### Recent Refactors
 - backend: centralized configuration in `main.go` via a `Config` struct and `loadConfig` helper
@@ -86,29 +85,20 @@ frontend/
 
 ---
 
-## 4. Current vs Planned Storage Layout
+## 4. Storage Layout
 
-### Current Storage
-- **Images**: stored under `IMAGE_DIR` (default `backend/images`). Subdirectories denote logical groupings.
-- **Timestamps**: legacy `metadata.json` or hashed entries in `metadata/<2-char-prefix>/<fullhash>.json`.
-- **Dialogs**: `dialogs/<hash>.json` (flat) or legacy nested layout.
-
-### Planned Unified Storage (`metadata/`)
-Under each image directory (e.g. `backend/images/` or nested `…/<subpath>/`), replace separate `dialogs/` and hashed JSON files with:
+Images reside under `IMAGE_DIR` (default `backend/images`). For each image the backend maintains a metadata directory based on the file's SHA‑256 hash:
 
 ```
 metadata/
-  └── <prefix>/                ← first 2 chars of SHA256(filename)
+  └── <prefix>/                ← first 2 characters of the hash
        └── <fullhash>/         ← full hex digest
-            ├── image          ← symlink to original image file
-            ├── timestamp.json ← JSON string, RFC3339Nano
-            ├── dialog.json    ← JSON array of strings
-            └── annotations.json ← (future) AI annotations
+            ├── image          ← symlink to the original image
+            ├── timestamp.json ← RFC3339Nano string
+            └── dialog.json    ← JSON array of strings
 ```
 
-- **Symlink**: name it `image` (no extension), pointing to the relative path of the image file.
-- **Updates**: On `SaveMetaEntry`, `MoveDialogEntry`, or file rename, the AI must update the corresponding symlink target.
-- **Backward Migration**: Provide one-time migration from existing `dialogs/` and `metadata/` files into the new layout.
+Legacy `metadata.json` and `dialogs/` files are migrated on demand.
 
 ---
 
@@ -182,14 +172,11 @@ docker-compose up --exit-code-from e2e frontend e2e  # run E2E
 ---
 
 ## 7. Next Steps
-1. **Implement Unified Metadata Layout**: refactor storage APIs to read/write dialog, timestamp, and annotations under the new `metadata/<prefix>/<fullhash>/` directories.
-2. **Symlink Management**: on file uploads, renames, and reorder operations, create/update a symlink named `image` in each leaf metadata folder pointing to the actual image.
-3. **Migration Tooling**: write a one-time migration to ingest existing `dialogs/` and timestamp entries into the new layout.
-4. **Extend Storage Model**: add `annotations.json` to accommodate future AI-generated metadata.
-5. **Componentize UI**: extract Lightbox (`<Lightbox>`) and dialog sidebar (`<DialogSidebar>`) into reusable components and hooks.
-6. **Styling System**: migrate to CSS Modules or styled-components for component-scoped styles and maintainable theming.
-7. **Typed API Client**: evaluate using a generated TypeScript client or a data-fetching library (e.g., React Query) for robust, type-safe API interactions.
-8. **Build Orchestration**: introduce a Makefile or npm script to automate `scripts/build-static.sh` prior to Go builds and unify the build pipeline.
+1. **Extend Storage Model**: add `annotations.json` to accommodate future AI-generated metadata.
+2. **Componentize UI**: extract Lightbox (`<Lightbox>`) and dialog sidebar (`<DialogSidebar>`) into reusable components and hooks.
+3. **Styling System**: migrate to CSS Modules or styled-components for component-scoped styles and maintainable theming.
+4. **Typed API Client**: evaluate using a generated TypeScript client or a data-fetching library (e.g., React Query) for robust, type-safe API interactions.
+5. **Build Orchestration**: introduce a Makefile or npm script to automate `scripts/build-static.sh` prior to Go builds and unify the build pipeline.
 
 ---
 *End of AI Assistant Guide*

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Image Processor
 
-This repository contains a Go-based backend and a React + TypeScript frontend for loading, displaying, and reordering a directory of images. Reordering is persisted to disk via a simple metadata file.
+This repository contains a Go-based backend and a React + TypeScript frontend for loading, displaying, and reordering images. Per-image metadata is stored under `metadata/<prefix>/<hash>/` directories. Each directory contains a symlink `image` back to the original file along with `timestamp.json` and `dialog.json`.
 
 ## Directory Structure
 - backend/: Go HTTP server (Gin), image API, and static image serving
+- backend/images/: default image directory with `metadata/` subfolder for per-image data
 - frontend/: React + TypeScript UI using Vite and dnd-kit for drag-and-drop
 
 ## Backend Setup
@@ -68,4 +69,13 @@ You can also run the end-to-end Playwright tests in Docker by bringing up the fr
 # This will build the e2e test image, start the frontend service, and run tests
 docker-compose up --exit-code-from e2e frontend e2e
 ```
+
+## Production Build
+
+To generate static frontend assets in `backend/static` run:
+
+```sh
+bash scripts/build-static.sh
+```
+
 > Note: The backend service uses **reflex** to watch for changes in `.go` files and will automatically rebuild and restart when you modify backend code.


### PR DESCRIPTION
## Summary
- document per-image metadata directories in README
- explain production build script
- clarify storage layout and next steps in AI_README

## Testing
- `go test ./...` *(fails: proxyconnect tcp: dial tcp 172.26.0.3:8080: connect: no route to host)*
- `npm test --silent` *(fails: vitest not found)*